### PR TITLE
add process_flag(trap_exit, true), in emysql_conn_mgr.erl init()

### DIFF
--- a/src/emysql_app.erl
+++ b/src/emysql_app.erl
@@ -25,7 +25,7 @@
 -module(emysql_app).
 -behaviour(application).
 
--export([start/2, stop/1, default_timeout/0, lock_timeout/0, pools/0, conn_test_period/0]).
+-export([start/2, stop/1, default_timeout/0, lock_timeout/0, pools/0, conn_test_period/0, prep_stop/1]).
 
 -include("emysql.hrl").
 

--- a/src/emysql_app.erl
+++ b/src/emysql_app.erl
@@ -39,9 +39,13 @@ start(_Type, _StartArgs) ->
     emysql_sup:start_link().
 
 stop(_State) ->
+	ok.
+
+prep_stop(State) ->
 	ok = lists:foreach(
 		fun (Pool) -> emysql:remove_pool(Pool#pool.pool_id) end,
-		emysql_conn_mgr:pools()).
+		emysql_conn_mgr:pools()),
+	State.
 
 default_timeout() ->
     case application:get_env(emysql, default_timeout) of

--- a/src/emysql_conn_mgr.erl
+++ b/src/emysql_conn_mgr.erl
@@ -146,6 +146,7 @@ init([]) ->
         end,
         initialize_pools()
     ),
+    process_flag(trap_exit, true),
     {ok, #state{pools=Pools}}.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
add process_flag(trap_exit, true) in emysql_conn_mgr:init(),
add Module:prep_stop(State) in emysql_app.erl and move the code in emysql_app:stop() to prep_stop(), to fix the bug which close connection failed when call application:stop(emysql)
